### PR TITLE
fix: Remove extra fetch; add conditional for localStorage

### DIFF
--- a/src/components/AdoptableCreatures/AdoptableCreatures.jsx
+++ b/src/components/AdoptableCreatures/AdoptableCreatures.jsx
@@ -8,18 +8,16 @@ const AdoptableCreatures = () => {
   const [error, setError] = useState('');
 
   useEffect(() => {
-    getAllCreatures()
-      .then(setCreatures);
-  }, []);
-
-  useEffect(() => {
     const savedCreatures = localStorage.getItem('creatures');
-    if (savedCreatures) setCreatures(JSON.parse(savedCreatures));
-    getAllCreatures()
-      .then((creatures) => {
-        setCreatures(creatures);
-        localStorage.setItem('creatures', JSON.stringify(creatures));
-      });
+    if (savedCreatures) {
+      setCreatures(JSON.parse(savedCreatures))
+    } else {
+      getAllCreatures()
+        .then((creatures) => {
+          setCreatures(creatures);
+          localStorage.setItem('creatures', JSON.stringify(creatures));
+        });
+    }
   }, []);
 
   return (


### PR DESCRIPTION
# Description
- Removes extraneous useEffect/fetch that was stopping localStorage from doing its job properly
- Adds `else` to conditional for localStorage so that the fetch _only_ fires if data isn't in localStorage

# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] My code follows the Turing Style Guides and best practices.
- [x] I ran the code locally and verified that there are no visible errors.
- [x] fix: My PR clearly describes the bug I'm fixing and why.