### PR TITLE
Fix/no results filter logic

### DIFF
--- a/src/components/AdoptableCreatures/AdoptableCreatures.css
+++ b/src/components/AdoptableCreatures/AdoptableCreatures.css
@@ -15,3 +15,7 @@
   text-decoration: none;
   color: inherit;
 }
+
+.no-results {
+  font-size: x-large;
+}

--- a/src/components/AdoptableCreatures/AdoptableCreatures.jsx
+++ b/src/components/AdoptableCreatures/AdoptableCreatures.jsx
@@ -44,8 +44,9 @@ const AdoptableCreatures = () => {
       setLoading(true);
       getAllCreatures()
         .then((creatures) => {
-          setCreatures(creatures);
-          localStorage.setItem('creatures', JSON.stringify(creatures));
+          const creaturesWithImage = creatures.filter((creature) => creature.image);
+          setCreatures(creaturesWithImage);
+          localStorage.setItem('creatures', JSON.stringify(creaturesWithImage));
         })
         .catch((error) => {
           console.error(error);


### PR DESCRIPTION
# Description
- Adds logic to set creatures to only those with images
  - Previously, only those with images were being rendered, but creatures was being set to all results
- Adds a tiny bit of styling to the message

# Screenshot(s)
<img width="733" alt="Screenshot 2024-01-14 at 8 31 27 PM" src="https://github.com/ericahagle/fantastical-foundlings/assets/133910120/5701a15a-9186-438a-a7e5-a013fffff621">

# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] My code follows the Turing Style Guides and best practices.
- [x] I ran the code locally and verified that there are no visible errors.
- [x] fix: My PR clearly describes the bug I'm fixing and why.