### PR TITLE
fix: Add logic to capitalize the first letter of each api returned value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "prop-types": "^15.8.1",
         "cypress": "^13.6.2",
+        "prop-types": "^15.8.1",
         "react-router-dom": "^6.21.1"
       }
     },

--- a/src/components/CreatureCard/CreatureCard.jsx
+++ b/src/components/CreatureCard/CreatureCard.jsx
@@ -2,6 +2,10 @@ import PropTypes from 'prop-types';
 import './CreatureCard.css';
 
 const CreatureCard = ({ creature, onClick }) => {
+  const capitalizeFirstLetter = (value) => {
+    return value.charAt(0).toUpperCase() + value.slice(1);
+  };
+
   return (
     <div className='CreatureCard font-face-bookman-bt-roman-headline' onClick={onClick}>
       <h3>{creature.name}</h3>
@@ -9,15 +13,15 @@ const CreatureCard = ({ creature, onClick }) => {
 
       <p>
         <strong>Size: </strong>
-        <span style={{ whiteSpace: 'pre' }}> {creature.size}</span>
+        <span style={{ whiteSpace: 'pre' }}> {capitalizeFirstLetter(creature.size)}</span>
       </p>
       <p>
         <strong>Type: </strong>
-        <span style={{ whiteSpace: 'pre' }}> {creature.type}</span>
+        <span style={{ whiteSpace: 'pre' }}> {capitalizeFirstLetter(creature.type)}</span>
       </p>
       <p>
         <strong>Alignment: </strong>
-        <span style={{ whiteSpace: 'pre' }}> {creature.alignment}</span>
+        <span style={{ whiteSpace: 'pre' }}> {capitalizeFirstLetter(creature.alignment)}</span>
       </p>
     </div>
 

--- a/src/components/CreatureDetail/CreatureDetail.jsx
+++ b/src/components/CreatureDetail/CreatureDetail.jsx
@@ -9,12 +9,19 @@ const CreatureDetail = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  const capitalizeFirstLetter = (value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    return value.charAt(0).toUpperCase() + value.slice(1);
+  };
+
   const renderElementIfExists = (label, value) => {
     if (value) {
       return (
         <p className='paragraph-of-details'>
           <strong className='detail-category'>{label}:</strong>
-          <span style={{ whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}> {value}</span>
+          <span style={{ whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}> {capitalizeFirstLetter(value)}</span>
         </p>
       );
     };


### PR DESCRIPTION
# Description
- Some of the values coming back from the api are not capitalized, but should be

# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] My code follows the Turing Style Guides and best practices.
- [x] I ran the code locally and verified that there are no visible errors.
- [x] fix: My PR clearly describes the bug I'm fixing and why.